### PR TITLE
parsing: Add support for wildcards and globbing

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -367,6 +367,7 @@ Send bug reports, suggestions, and questions to ulfalizer a.t Google's email
 service, or open a ticket on the GitHub page.
 """
 import errno
+import glob
 import os
 import platform
 import re
@@ -997,34 +998,45 @@ class Kconfig(object):
     # File reading
     #
 
-    def _open(self, filename):
+    def _resolve(self, filename, globbing):
         """
-        First tries to open 'filename', then '$srctree/filename' if $srctree
+        First tries with 'filename', then '$srctree/filename' if $srctree
         was set when the configuration was loaded.
         """
+        if os.path.isfile(filename):
+            return [filename]
+
+        if not os.path.isabs(filename) and self.srctree is not None:
+                filename = os.path.join(self.srctree, filename)
+
+        if os.path.isfile(filename):
+            return [filename]
+
+        if globbing:
+            # Try globbing
+            return glob.glob(filename)
+
+        raise IOError(
+            "Could not find '{}'. Perhaps the $srctree "
+            "environment variable (which was {}) is set incorrectly. Note "
+            "that the current value of $srctree is saved when the Kconfig "
+            "instance is created (for consistency and to cleanly "
+            "separate instances)."
+            .format(filename,
+                    "unset" if self.srctree is None else
+                    '"{}"'.format(self.srctree)))
+
+    def _open(self, filename):
+        """
+        Normalize the filename based on $srctree
+        """
+        filename = self._resolve(filename, False)[0]
         try:
             return open(filename)
         except IOError as e:
-            if not os.path.isabs(filename) and self.srctree is not None:
-                filename = os.path.join(self.srctree, filename)
-                try:
-                    return open(filename)
-                except IOError as e2:
-                    # This is needed for Python 3, because e2 is deleted after
-                    # the try block:
-                    #
-                    # https://docs.python.org/3/reference/compound_stmts.html#the-try-statement
-                    e = e2
-
             raise IOError(
-                "Could not open '{}' ({}: {}). Perhaps the $srctree "
-                "environment variable (which was {}) is set incorrectly. Note "
-                "that the current value of $srctree is saved when the Kconfig "
-                "instance is created (for consistency and to cleanly "
-                "separate instances)."
-                .format(filename, errno.errorcode[e.errno], e.strerror,
-                        "unset" if self.srctree is None else
-                        '"{}"'.format(self.srctree)))
+                "Could not open '{}' ({}: {})."
+                .format(filename, errno.errorcode[e.errno], e.strerror))
 
     def _enter_file(self, filename):
         """
@@ -1456,12 +1468,15 @@ class Kconfig(object):
                 prev_node.next = prev_node = node
 
             elif t0 == _T_SOURCE:
-                self._enter_file(self._expand_syms(self._next_token()))
-                prev_node = self._parse_block(None,            # end_token
-                                              parent,
-                                              visible_if_deps,
-                                              prev_node)
-                self._leave_file()
+                f = self._expand_syms(self._next_token())
+                f = self._resolve(f, True)
+                for s in f:
+                    self._enter_file(s)
+                    prev_node = self._parse_block(None,            # end_token
+                                                  parent,
+                                                  visible_if_deps,
+                                                  prev_node)
+                    self._leave_file()
 
             elif t0 == end_token:
                 # We have reached the end of the block. Terminate the final


### PR DESCRIPTION
Some projects use wildcards when sourcing a Kconfig file. Add support
for globbing the files that match the wildcards and process them one by
one.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
Signed-off-by: Anas Nashif <anas.nashif@intel.com>