### PR TITLE
Support disabling warnings for redundant assignments

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -486,6 +486,7 @@ class Kconfig(object):
     __slots__ = (
         "_choices",
         "_print_undef_assign",
+        "_print_redun_assign",
         "_print_warnings",
         "_set_re_match",
         "_unset_re_match",
@@ -561,6 +562,7 @@ class Kconfig(object):
 
         self._print_warnings = warn
         self._print_undef_assign = False
+        self._print_redun_assign = True
 
         self.syms = {}
         self.const_syms = {}
@@ -808,10 +810,14 @@ class Kconfig(object):
                         display_val = val
                         display_user_val = sym.user_value
 
-                    self._warn('{} set more than once. Old value: "{}", new '
-                               'value: "{}".'
-                               .format(name, display_user_val, display_val),
-                               filename, linenr)
+                    warn_msg = '{} set more than once. Old value: "{}", new value: "{}".'.format(
+                        name, display_user_val, display_val
+                    )
+
+                    if display_user_val == display_val:
+                        self._warn_redun_assign(warn_msg, filename, linenr)
+                    else:
+                        self._warn(             warn_msg, filename, linenr)
 
                 sym.set_value(val)
 
@@ -1032,6 +1038,19 @@ class Kconfig(object):
         """
         self._print_undef_assign = False
 
+    def enable_redun_warnings(self):
+        """
+        Enables warnings for redundant assignments to symbols. Printed to
+        stderr. Enabled by default.
+        """
+        self._print_redun_assign = True
+
+    def disable_redun_warnings(self):
+        """
+        See enable_redun_warnings().
+        """
+        self._print_redun_assign = False
+
     def __repr__(self):
         """
         Returns a string with information about the Kconfig object when it is
@@ -1046,6 +1065,8 @@ class Kconfig(object):
             "warnings " + ("enabled" if self._print_warnings else "disabled"),
             "undef. symbol assignment warnings " +
                 ("enabled" if self._print_undef_assign else "disabled"),
+            "redundant symbol assignment warnings " +
+                ("enabled" if self._print_redun_assign else "disabled")
         )))
 
     #
@@ -2122,6 +2143,12 @@ class Kconfig(object):
             'attempt to assign the value "{}" to the undefined symbol {}' \
             .format(val, name), filename, linenr)
 
+    def _warn_redun_assign(self, msg, filename=None, linenr=None):
+        """
+        See the class documentation.
+        """
+        if self._print_redun_assign:
+            _stderr_msg("warning: " + msg, filename, linenr)
 
 class Symbol(object):
     """

--- a/testsuite.py
+++ b/testsuite.py
@@ -676,7 +676,7 @@ choice
     print("Testing Kconfig.__repr__()")
 
     verify_repr(c, """
-<configuration with 15 symbols, main menu prompt "Linux Kernel Configuration", srctree not set, config symbol prefix "CONFIG_", warnings disabled, undef. symbol assignment warnings disabled>
+<configuration with 15 symbols, main menu prompt "Linux Kernel Configuration", srctree not set, config symbol prefix "CONFIG_", warnings disabled, undef. symbol assignment warnings disabled, redundant symbol assignment warnings enabled>
 """)
 
     os.environ["srctree"] = "srctree value"
@@ -684,10 +684,11 @@ choice
 
     c = Kconfig("Kconfiglib/tests/Krepr", warn=False)
     c.enable_warnings()
+    c.disable_redun_warnings()
     c.enable_undef_warnings()
 
     verify_repr(c, """
-<configuration with 15 symbols, main menu prompt "Linux Kernel Configuration", srctree "srctree value", config symbol prefix "CONFIG_ value", warnings enabled, undef. symbol assignment warnings enabled>
+<configuration with 15 symbols, main menu prompt "Linux Kernel Configuration", srctree "srctree value", config symbol prefix "CONFIG_ value", warnings enabled, undef. symbol assignment warnings enabled, redundant symbol assignment warnings disabled>
 """)
 
     os.environ.pop("srctree", None)
@@ -1816,6 +1817,8 @@ def test_sanity(conf, arch):
     conf.modules
     conf.defconfig_list
     conf.defconfig_filename
+    conf.enable_redun_warnings()
+    conf.disable_redun_warnings()
     conf.enable_undef_warnings()
     conf.disable_undef_warnings()
     conf.enable_warnings()


### PR DESCRIPTION
The Linux Kernel's merge_config.sh defaults to disabling warnings for
redundant assignments and has support for enabling them
specifically. This patch reproduces this behaviour in kconfiglib
except that we retain kconfiglib's default behaviour of enabling the
warnings.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>