### PR TITLE
Decode sources as UTF-8 instead of relying on the system locale

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -358,6 +358,7 @@ import os
 import platform
 import re
 import sys
+import io
 
 # File layout:
 #
@@ -1314,12 +1315,12 @@ class Kconfig(object):
         # was set when the configuration was loaded
 
         try:
-            return open(filename, _UNIVERSAL_NEWLINES_MODE)
+            return io.open(filename, _UNIVERSAL_NEWLINES_MODE, encoding='utf-8')
         except IOError as e:
             if not os.path.isabs(filename) and self.srctree is not None:
                 filename = os.path.join(self.srctree, filename)
                 try:
-                    return open(filename, _UNIVERSAL_NEWLINES_MODE)
+                    return io.open(filename, _UNIVERSAL_NEWLINES_MODE, encoding='utf-8')
                 except IOError as e2:
                     # This is needed for Python 3, because e2 is deleted after
                     # the try block:


### PR DESCRIPTION
Opening files without specifying an encoding will cause the system
locale to determine the encoding. It is undesired behaviour IMHO that
reading/decoding Kconfig sources is platform-dependent, instead
kconfiglib should behave in the same way on all platforms.

Example:

$ export LANG=C
$ echo "# Author: Sebastian Bøe" >> Kconfig
$ test_kconfig_lib.py

Alternatively, one could decode as ascii, especially if it is
explicitly documented that Kconfig sources (including comments) must
be ascii.

The most important thing is that kconfiglib behaves the same on all
platforms.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>