### PR TITLE
Fix the 'source "$ENV/xx/yy"' not found issue when defined the 'ENV' …

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -2822,6 +2822,12 @@ class Kconfig(object):
 
                 self._parse_properties(node)
 
+                if node.item.env_var:
+                    if node.item.env_var in os.environ:
+                        os.environ[node.item.name] = os.environ[node.item.env_var]
+                    else:
+                        os.environ[node.item.name] = ((node.defaults[0])[0]).name
+
                 if node.is_menuconfig and not node.prompt:
                     self._warn("the menuconfig symbol {} has no prompt"
                                .format(_name_and_loc(sym)))


### PR DESCRIPTION
…by 'config ENV'.

testcase like this:

```
config RTT_DIR
    string
    option env="RTT_ROOT"
    default "../../.."

source "$RTT_DIR/Kconfig"
```