### PR TITLE
Change all hashbangs to use python3

### DIFF
--- a/alldefconfig.py
+++ b/alldefconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/allmodconfig.py
+++ b/allmodconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/allnoconfig.py
+++ b/allnoconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/allyesconfig.py
+++ b/allyesconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/defconfig.py
+++ b/defconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/examples/menuconfig_example.py
+++ b/examples/menuconfig_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Implements a simple configuration interface on top of Kconfiglib to
 # demonstrate concepts for building a menuconfig-like. Emulates how the

--- a/examples/merge_config.py
+++ b/examples/merge_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script functions similarly to scripts/kconfig/merge_config.sh from the
 # kernel tree, merging multiple configurations fragments to produce a complete

--- a/genconfig.py
+++ b/genconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/guiconfig.py
+++ b/guiconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/listnewconfig.py
+++ b/listnewconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/menuconfig.py
+++ b/menuconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Nordic Semiconductor ASA and Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/oldconfig.py
+++ b/oldconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/olddefconfig.py
+++ b/olddefconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/savedefconfig.py
+++ b/savedefconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/setconfig.py
+++ b/setconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC


### PR DESCRIPTION
Now that Python 2 is pretty much dead, change all script hashbangs to use
/usr/bin/env python3.

Nothing else is changed: the module still supports Python 2, and when installing
with python2 the entry_point bounce scripts have a python2 hashbang.

Closes #89.