### PR TITLE
menuconfig: Avoid crashing when leaving a menu not shown in parent

### DIFF
--- a/menuconfig.py
+++ b/menuconfig.py
@@ -1202,7 +1202,12 @@ def _leave_menu():
     # Jump to parent menu
     parent = _parent_menu(_cur_menu)
     _shown = _shown_nodes(parent)
-    _sel_node_i = _shown.index(_cur_menu)
+
+    try:
+        _sel_node_i = _shown.index(_cur_menu)
+    except ValueError:
+        _sel_node_i = 0
+
     _cur_menu = parent
 
     # Try to make the menu entry appear on the same row on the screen as it did


### PR DESCRIPTION
This adds a catch to an exception that might occur when leaving a menu which is not shown by the parent menu. For an example of this refer to issue #93.

For the snippet given in #93 this ends up showing the top menu. I'm not sure if this is the expected behaviour (after all, the second definition of the choice is defined in the top menu), or 'Sub' menu should be shown. At least this seems to avoid the crash.