### PR TITLE
Support printing negatives in Kconfig.write_autoconf()

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -57,6 +57,16 @@ otherwise.
 """)
 
     parser.add_argument(
+        "--header-include-negatives",
+        action="store_true",
+        dest="negatives",
+        help="""
+If enabled, the generated header file will include defines to 0 for false
+values. If not specified, this feature will be enabled if the environment
+variable KCONFIG_NEGATIVES is set.
+""")
+
+    parser.add_argument(
         "--config-out",
         metavar="CONFIG_FILE",
         help="""
@@ -114,15 +124,15 @@ only supported for backwards compatibility).
 
     if args.header_path is None:
         if "KCONFIG_AUTOHEADER" in os.environ:
-            kconf.write_autoconf()
+            kconf.write_autoconf(negatives=args.negatives)
         else:
             # Kconfiglib defaults to include/generated/autoconf.h to be
             # compatible with the C tools. 'config.h' is used here instead for
             # backwards compatibility. It's probably a saner default for tools
             # as well.
-            kconf.write_autoconf("config.h")
+            kconf.write_autoconf("config.h", negatives=args.negatives)
     else:
-        kconf.write_autoconf(args.header_path)
+        kconf.write_autoconf(args.header_path, negatives=args.negatives)
 
     if args.config_out is not None:
         kconf.write_config(args.config_out, save_old=False)

--- a/tests/Knegatives
+++ b/tests/Knegatives
@@ -1,0 +1,6 @@
+config BOOL1
+	bool "B1"
+	default y
+
+config BOOL2
+	bool "B2"

--- a/testsuite.py
+++ b/testsuite.py
@@ -84,6 +84,9 @@ def verify_equal(x, y):
 # KCONFIG_ALLCONFIG from the environment
 os.environ.pop("KCONFIG_ALLCONFIG", None)
 
+# Don't let value of KCONFIG_NEGATIVES interfere with tests.
+os.environ.pop("KCONFIG_NEGATIVES", None)
+
 obsessive = False
 obsessive_min_config = False
 log = False
@@ -2044,6 +2047,22 @@ header header from env.
     del os.environ["KCONFIG_CONFIG_HEADER"]
     del os.environ["KCONFIG_AUTOHEADER_HEADER"]
 
+    print("Testing header generation without negatives")
+
+    c = Kconfig("Kconfiglib/tests/Knegatives")
+    c.write_autoconf(config_test_file, negatives=False)
+    verify_file_contents(config_test_file, """\
+#define CONFIG_BOOL1 1
+""")
+
+    print("Testing header generation with negatives")
+
+    c = Kconfig("Kconfiglib/tests/Knegatives")
+    c.write_autoconf(config_test_file, negatives=True)
+    verify_file_contents(config_test_file, """\
+#define CONFIG_BOOL1 1
+#define CONFIG_BOOL2 0
+""")
 
     print("Testing Kconfig fetching and separation")
 


### PR DESCRIPTION
Some forks of the C implementation of Kconfig (notably, used in
coreboot and depthcharge) offer an option to include false values
defined to zero in generated header files.

This adds support for an equivalent feature to Kconfiglib, so it can
be made use of in those codebases.