### PR TITLE
menuconfig: fix crash caused by unsupported locales

### DIFF
--- a/menuconfig.py
+++ b/menuconfig.py
@@ -703,8 +703,12 @@ def menuconfig(kconf):
     # errors ourselves.
     kconf.warn = False
 
-    # Make curses use the locale settings specified in the environment
-    locale.setlocale(locale.LC_ALL, "")
+    try:
+        # Make curses use the locale settings specified in the environment
+        locale.setlocale(locale.LC_ALL, "")
+    except locale.Error:
+        # fall back to the default locale
+        locale.setlocale(locale.LC_ALL, "C")
 
     # Try to fix Unicode issues on systems with bad defaults
     if _CHANGE_C_LC_CTYPE_TO_UTF8:


### PR DESCRIPTION
When run on a system with an unsupported locale setting (e.g. `LC_TIME=en_DE.UTF-8`), menuconfig.py crashes with the following message:

    locale.Error: unsupported locale setting

This fixes it by using the default locale if an unsupported locale is encountered.