### PR TITLE
fix(menuconfig): allow choice override menuconfig

### DIFF
--- a/menuconfig.py
+++ b/menuconfig.py
@@ -1202,7 +1202,26 @@ def _leave_menu():
     # Jump to parent menu
     parent = _parent_menu(_cur_menu)
     _shown = _shown_nodes(parent)
-    _sel_node_i = _shown.index(_cur_menu)
+
+    try:
+        _sel_node_i = _shown.index(_cur_menu)
+    except ValueError:
+        # Since we can have choice overrides sprinkled throughout the tree
+        # we must handle the case of a overridden choice symbol containing
+        # a menuconfig.
+        # Simply taking the parent of the overridden choice symbol will not
+        # be able to navigate back, thus, not able to figure out the index.
+        # Insead we have to look in the items for the choice override with
+        # the prompt to go back to that location.
+        for node in _cur_menu.item.nodes:
+            try:
+                parent = _parent_menu(node)
+                _shown = _shown_nodes(parent)
+                _sel_node_i = _shown.index(node)
+                break
+            except ValueError:
+                pass
+
     _cur_menu = parent
 
     # Try to make the menu entry appear on the same row on the screen as it did


### PR DESCRIPTION
Hi :wave: 

I have encountered this issue when spending far too much time with kconfig and RIOT...

Handle special cases when having a choice override with a menuconfig.

This is a bit more complete solution to #94

<details><summary>The failure can be checked with:</summary>

```kconfig

config PRE
    bool "Pre prompt"

choice OVERRIDE_ME

menuconfig PRE_MENUCONFIG
    bool "PRE_MENUCONFIG prompt"

config PRE_CONFIG
    bool "PRE_CONFIG prompt"
    depends on PRE_MENUCONFIG

endchoice

menuconfig FOO
    bool "FOO prompt"

if FOO

config FOOPRE
    bool "FOOPRE prompt"

choice OVERRIDE_ME
    bool "OVERRIDE_ME prompt"

menuconfig DOES_NOT_CRASH_MENUCONFIG
    bool "DOES_NOT_CRASH_MENUCONFIG prompt"

config DOES_NOT_CRASH_CONFIG
    bool "DOES_NOT_CRASH_CONFIG prompt"
    depends on DOES_NOT_CRASH_MENUCONFIG

endchoice

config FOOPOST
    bool "FOOPOST prompt"

endif

choice OVERRIDE_ME

menuconfig POST_MENUCONFIG
    bool "POST_MENUCONFIG prompt"

config POST_CONFIG
    bool "POST_CONFIG prompt"
    depends on POST_MENUCONFIG

endchoice

config POST
    bool "POST prompt"

```
</details>

Here is the failure and solution in action...
![Peek 2023-01-03 12-42](https://user-images.githubusercontent.com/19396439/210351039-544becad-bcb8-4d62-b2b6-42c10d1f6475.gif)

